### PR TITLE
Gamepad fix

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,6 @@
+Unreleased
+- Fixed bug where an unmapped controller won't properly connect upon startup
+
 v1.5 (2022-2-28)
 - Added :fork special command
 - Enabled VSync

--- a/src/launcher.c
+++ b/src/launcher.c
@@ -1179,15 +1179,14 @@ int main(int argc, char *argv[])
   validate_settings(&geo);
 
   // Load gamepad overrides
-  if (config.gamepad_enabled) {
-    if (config.gamepad_mappings_file != NULL) {
-      error = SDL_GameControllerAddMappingsFromFile(config.gamepad_mappings_file);
-      if (error) {
-        output_log(LOGLEVEL_ERROR, 
-          "Error: Could not load gamepad mappings from %s\n", 
-          config.gamepad_mappings_file
-        );
-      }
+  if (config.gamepad_enabled && config.gamepad_mappings_file != NULL) {
+    error = SDL_GameControllerAddMappingsFromFile(config.gamepad_mappings_file);
+    if (error < 0) {
+      output_log(LOGLEVEL_ERROR, 
+        "Error: Could not load gamepad mappings from %s\n%s\n", 
+        config.gamepad_mappings_file,
+        SDL_GetError()
+      );
     }
   }
 

--- a/src/launcher.c
+++ b/src/launcher.c
@@ -1294,16 +1294,18 @@ int main(int argc, char *argv[])
           }
           break;
           
-        case SDL_CONTROLLERDEVICEADDED:
-          output_log(LOGLEVEL_DEBUG, "Gamepad connected with device index %i\n", event.cdevice.which);
-          if (event.cdevice.which == config.gamepad_device) {
-            connect_gamepad(event.cdevice.which);
+        case SDL_JOYDEVICEADDED:
+          if (SDL_IsGameController(event.jdevice.which) == SDL_TRUE) {
+            output_log(LOGLEVEL_DEBUG, "Gamepad connected with device index %i\n", event.jdevice.which);
+            if (event.jdevice.which == config.gamepad_device) {
+              connect_gamepad(event.jdevice.which);
+            }
           }
           break;
 
-        case SDL_CONTROLLERDEVICEREMOVED:
-          output_log(LOGLEVEL_DEBUG, "Gamepad removed with device index %i\n", event.cdevice.which);
-          if (event.cdevice.which == config.gamepad_device) {
+        case SDL_JOYDEVICEREMOVED:
+          if (event.jdevice.which == config.gamepad_device && gamepad != NULL) {
+            output_log(LOGLEVEL_DEBUG, "Gamepad disconnected\n");
             SDL_GameControllerClose(gamepad);
             gamepad = NULL;
           }


### PR DESCRIPTION
Use Joypad events instead of GameController events to connect and disconnect a gamepad, because controllers without a mapping in SDL won't generate a GameController event on startup. Fixes #6 