### PR TITLE
Fix output on secondary monitor by rendering via OpenGL

### DIFF
--- a/src/launcher.c
+++ b/src/launcher.c
@@ -221,7 +221,7 @@ static void create_window()
                  SDL_WINDOWPOS_UNDEFINED,
                  0,
                  0,
-                 SDL_WINDOW_FULLSCREEN_DESKTOP | SDL_WINDOW_BORDERLESS
+                 SDL_WINDOW_FULLSCREEN_DESKTOP | SDL_WINDOW_BORDERLESS | SDL_WINDOW_OPENGL
              );
     if (window == NULL)
         log_fatal("Could not create SDL Window\n%s", SDL_GetError());


### PR DESCRIPTION
On my home server the primary screen is connected to a KVM and the secondary to my TV. With the standard settings (I assume it defaults to Vulkan then?) it renders a black screen on the secondary monitor. When compiled with `SDL_WINDOW_OPENGL` it works as expected.

I am starting flex-launcher via gamescope:

```sh
gamescope --hdr-enabled -W 1920 -H 1080 -O HDMI-A-2 -f -- flex-launcher
```

Possibly related: #45