### PR TITLE
Unix now uses XDG paths to find icons, making it easier to provide im…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 docs/Gemfile.lock
 docs/_site
 docs/.jekyll-cache
+build/

--- a/src/image.h
+++ b/src/image.h
@@ -28,6 +28,9 @@ void render_scroll_indicators(Scroll *scroll, int height, Geometry *geo);
 SDL_Surface *load_next_slideshow_background(Slideshow *slideshow, bool transition);
 int load_next_slideshow_background_async(void *data);
 SDL_Texture *load_texture(SDL_Surface *surface);
+#ifdef __unix__
+SDL_Surface *load_surface_from_xdg(const char *path);
+#endif
 SDL_Texture *load_texture_from_file(const char *path);
 SDL_Texture *rasterize_svg(char *buffer, int w, int h, SDL_Rect *rect);
 SDL_Texture *rasterize_svg_from_file(const char *path, int w, int h, SDL_Rect *rect);


### PR DESCRIPTION
…ages. Defaulting to hicolor for icons.


I'm not much of a C programmer so hopefully the code is passable. This makes it so one can just do like `Entry4=Retroarch;org.libretro.RetroArch.svg;flatpak run org.libretro.RetroArch` and it'll find the correct svg for you(Though ideally if you specify a .desktop it'd do the whole search for you)