### PR TITLE
Parses desktop files when provided as the only argument on unix, making it even easier to configure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 docs/Gemfile.lock
 docs/_site
 docs/.jekyll-cache
+build/

--- a/src/image.c
+++ b/src/image.c
@@ -122,8 +122,9 @@ SDL_Surface *load_surface_from_xdg(const char *path){
         "64x64",
         "32x32"
     };
+    const char* exts[] = {"", ".svg", ".png"};
 
-    for(int i = 0; i < sizeof(sizes) / sizeof(void*); i++){
+    for(int i = 0; i < sizeof(sizes) / sizeof(sizes[0]); i++){
         char icon_path[128] = {};
         snprintf(icon_path, 127, "/icons/hicolor/%s/apps/", sizes[i]);
 
@@ -140,9 +141,14 @@ SDL_Surface *load_surface_from_xdg(const char *path){
                 memcpy(&xdg_path, &xdg_dirs[start_ind], end);
                 memcpy(&xdg_path[end], icon_path, strlen(icon_path));
                 memcpy(&xdg_path[end + strlen(icon_path)], path, strlen(path));
-                surface = IMG_Load(xdg_path);
-                if (surface != NULL)
-                    return surface;
+                for(int j = 0; j < sizeof(exts) / sizeof(exts[0]); j++){
+                    memcpy(&xdg_path[end + strlen(icon_path) + strlen(path)], exts[j], strlen(exts[j]));
+                    surface = IMG_Load(xdg_path);
+                    if (surface != NULL)
+                        return surface;
+                }
+
+
 
                 last_delim += end + 1;
             }

--- a/src/image.h
+++ b/src/image.h
@@ -28,6 +28,9 @@ void render_scroll_indicators(Scroll *scroll, int height, Geometry *geo);
 SDL_Surface *load_next_slideshow_background(Slideshow *slideshow, bool transition);
 int load_next_slideshow_background_async(void *data);
 SDL_Texture *load_texture(SDL_Surface *surface);
+#ifdef __unix__
+SDL_Surface *load_surface_from_xdg(const char *path);
+#endif
 SDL_Texture *load_texture_from_file(const char *path);
 SDL_Texture *rasterize_svg(char *buffer, int w, int h, SDL_Rect *rect);
 SDL_Texture *rasterize_svg_from_file(const char *path, int w, int h, SDL_Rect *rect);

--- a/src/launcher.c
+++ b/src/launcher.c
@@ -723,6 +723,7 @@ static void move_right()
         calculate_button_geometry(current_menu->root_entry, (int) buttons);
         if (config.highlight)
             highlight->rect.x = current_entry->icon_rect.x - config.highlight_hpadding;
+            highlight->rect.x = current_entry->icon_rect.x - config.highlight_hpadding;
         current_menu->page++;
         current_menu->highlight_position = 0;
     }

--- a/src/util.h
+++ b/src/util.h
@@ -23,6 +23,11 @@ struct gamepad_info {
 };
 
 int config_handler(void *user, const char *section, const char *name, const char *value);
+#ifdef __unix__
+int desktop_config_handler(void *user, const char *section, const char *name, const char *value);
+Entry parse_possible_desktop_file(const char* name);
+#endif
+
 int convert_percent(const char *string, int max_value);
 const char *get_mode_setting(int type, int value);
 int utf8_length(const char *string);


### PR DESCRIPTION
Now users on Unix can just specify `Entry1=steam.desktop` and it will find and load the correct files and commands for the user.


Relies on #90 